### PR TITLE
Fix city-state unique validation warnings

### DIFF
--- a/jsons/CityStateTypes.json
+++ b/jsons/CityStateTypes.json
@@ -126,8 +126,8 @@
         ],
         "allyBonusUniques": [
             "[+2 Culture] [in capital]",
-            "[+50]% Culture from every [Landmark]",
-            "[+50]% Culture from every [Acropolis]",
+            "[+50]% [Culture] from every [Landmark]",
+            "[+50]% [Culture] from every [Acropolis]",
         ],
         "color": [
             255,
@@ -202,7 +202,7 @@
             "[+2 Production] from every [Manufactory]",
             "[+2 Production] from every [Hansa]",
             "[+2 Production] from every [Oppidum]",
-            "Provides [2] [Power] <in all cities with a [Harbor District]>"
+            "Provides [2] [Power] <in cities with a [Harbor District]>"
         ],
         "color": [
             254,


### PR DESCRIPTION
## Summary
- Fixes Vilnius ally bonus uniques by wrapping `Culture` in brackets for percent yield modifiers.
- Fixes Cardiff's Power bonus city filter by using Unciv's recognized `<in cities with a [buildingFilter]>` conditional.

## Why
Unciv was warning that the Vilnius culture modifiers were untyped uniques, and that Cardiff's Harbor District conditional used an unknown filter form.

## Validation
- Ran the Unciv mod-ci validator locally.
- Confirmed the three reported warnings no longer appear.
- Existing repo-wide options-only warnings remain unchanged.

<img width="677" height="259" alt="Screenshot 2026-06-14 at 8 22 54 AM" src="https://github.com/user-attachments/assets/e3cbaef5-8ac5-48f2-8ccf-4b8f18ef2125" />
