### PR TITLE
Fix unit filter validation warnings

### DIFF
--- a/jsons/CityStateTypes.json
+++ b/jsons/CityStateTypes.json
@@ -295,7 +295,8 @@
         "allyBonusUniques": [
             "[+15]% Production when constructing [Military] units [in all cities] <in cities with a [Barracks]>",
             "[+25]%  Strength <for [Melee] units> <vs cities> <when attacking>",
-            "[+25]%  Strength <for [Mounted] units> <vs cities> <when attacking>",
+            "[+25]%  Strength <for [Light Cavalry] units> <vs cities> <when attacking>",
+            "[+25]%  Strength <for [Heavy Cavalry] units> <vs cities> <when attacking>",
         ],
         "color": [
             202,
@@ -542,7 +543,7 @@
             "[+2 Faith] [in capital]",
             "[+2 Faith] from every [Holy site]",
             "[+2 Faith] from every [Lavra]",
-            "[+33]% Spread Religion Strength <for [Apostle] units>"
+            "[+33]% Spread Religion Strength <for [Religious Unit] units>"
         ],
         "color": [
             249,

--- a/jsons/UnitPromotions.json
+++ b/jsons/UnitPromotions.json
@@ -1017,7 +1017,7 @@
 		],
 		"uniques": [
 			"[+113]% Strength <vs [Heavy Cavalry] units>",
-			"[+113]% Strength <vs [Light] units>"
+			"[+113]% Strength <vs [Light Cavalry] units>"
 		],
 		"unitTypes": [
 			"Air Fighter"


### PR DESCRIPTION
## Summary
- Updates Tank Buster to target `Light Cavalry` instead of the invalid `Light` unit filter.
- Splits Akkad's mounted combat bonus into valid `Light Cavalry` and `Heavy Cavalry` filters.
- Updates Yerevan's religion spread bonus to target implemented `Religious Unit` units instead of the missing `Apostle` filter.

## Why
Unciv's validator was warning that `Light`, `Mounted`, and `Apostle` did not match valid `mapUnitFilter` values in this ruleset.

## Validation
- Ran the Unciv mod-ci validator locally.
- Confirmed the three unit filter/type warnings no longer appear.
- Note: warnings from the previous city-state unique PR still appear on this branch until that PR is merged.